### PR TITLE
Update yii2-backend-module version constraint

### DIFF
--- a/composer.phd5.json
+++ b/composer.phd5.json
@@ -8,7 +8,7 @@
         "dmstr/lajax-yii2-translate-manager-addons": "^1.0.0",
         "codemix/yii2-localeurls": "^1.7.1",
         "codemix/yii2-streamlog": "^1.2.1",
-        "dmstr/yii2-backend-module": "^1.0.1",
+        "dmstr/yii2-backend-module": "^1.0.2",
         "dmstr/yii2-contact-module": "^0.2.1",
         "dmstr/yii2-db": "^1.0.0-alpha1",
         "dmstr/yii2-helpers": ">=0.4.16",


### PR DESCRIPTION
Due to some changes made in the dmstr/yii2-backend-module repository.

Test `WidgetsModuleCept ` will fail because test stack uses outdated version of firefox which will show out dated message on top of backend layout's navbar, which in turn hides the button that is used to save data from test.