### PR TITLE
Removed deprecated widget-copy command

### DIFF
--- a/config/console.php
+++ b/config/console.php
@@ -9,8 +9,6 @@
  * file that was distributed with this source code
  */
 
-use hrzg\widget\commands\CopyController;
-
 return [
     'controllerNamespace' => 'app\commands',
     'controllerMap' => [
@@ -68,8 +66,7 @@ return [
             ],
         ],
         'rbac' => \dmstr\helpers\RbacController::class,
-        'translate' => \lajax\translatemanager\commands\TranslatemanagerController::class,
-        'widgets-copy' => CopyController::class
+        'translate' => \lajax\translatemanager\commands\TranslatemanagerController::class
     ],
     'components' => [
         'log' => [


### PR DESCRIPTION
Removed this because copy command is deprecated since v.2.5.0-rc1 of dmstr/yii2-widgets2-module