### PR TITLE
Added configurable local domain for mailer

### DIFF
--- a/config/common.php
+++ b/config/common.php
@@ -265,7 +265,8 @@ return [
                 'port' => getenv('APP_MAILER_PORT'),
                 'encryption' => getenv('APP_MAILER_ENCRYPTION'),
                 'username' => getenv('APP_MAILER_USERNAME'),
-                'password' => getenv('APP_MAILER_PASSWORD')
+                'password' => getenv('APP_MAILER_PASSWORD'),
+                'localDomain' => getenv('APP_MAILER_LOCAL_DOMAIN') ?: '127.0.0.1'
             ],
             'messageConfig' => [
                 'charset' => 'UTF-8',


### PR DESCRIPTION
Set default to mailer default (see [swiftmailer](https://github.com/swiftmailer/swiftmailer/blob/master/lib/classes/Swift/Transport/AbstractSmtpTransport.php#L25)) so we can set if to another value if needed